### PR TITLE
Avoid segfault if receiving confirm msg before commit msg

### DIFF
--- a/src/ap/ieee802_11.c
+++ b/src/ap/ieee802_11.c
@@ -501,8 +501,9 @@ static void handle_auth_sae(struct hostapd_data *hapd, struct sta_info *sta,
 			}
 		}
 	} else if (auth_transaction == 2) {
-		if (sta->sae->state != SAE_COMMITTED &&
-		    sta->sae->state != SAE_CONFIRMED) {
+		if ((sta->sae->state != SAE_COMMITTED &&
+		     sta->sae->state != SAE_CONFIRMED) ||
+		    !(sta->sae->peer_commit_scalar)) {
 			hostapd_logger(hapd, sta->addr,
 				       HOSTAPD_MODULE_IEEE80211,
 				       HOSTAPD_LEVEL_DEBUG,


### PR DESCRIPTION
```
From 0140bed2a0f7e3e155b95d7e8029e60cd497f8f0 Mon Sep 17 00:00:00 2001
From: Chun-Yeow Yeoh <yeohchunyeow@cozybit.com>
Date: Fri, 2 Aug 2013 16:33:41 -0700
Subject: [PATCH] mesh: return if peer commit scalar is NULL to avoid segfault

This checking is to ensure that we have received the commit message
from the peer mesh STA before doing sae_check_confirm.

Signed-off-by: Chun-Yeow Yeoh <yeohchunyeow@cozybit.com>

---
 src/ap/ieee802_11.c |    5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)

diff --git a/src/ap/ieee802_11.c b/src/ap/ieee802_11.c
index f550bfd..2566fa8 100644
--- a/src/ap/ieee802_11.c
+++ b/src/ap/ieee802_11.c
@@ -501,8 +501,9 @@ static void handle_auth_sae(struct hostapd_data *hapd, struct sta_info *sta,
            }
        }
    } else if (auth_transaction == 2) {
-       if (sta->sae->state != SAE_COMMITTED &&
-           sta->sae->state != SAE_CONFIRMED) {
+       if ((sta->sae->state != SAE_COMMITTED &&
+            sta->sae->state != SAE_CONFIRMED) ||
+           !(sta->sae->peer_commit_scalar)) {
            hostapd_logger(hapd, sta->addr,
                       HOSTAPD_MODULE_IEEE80211,
                       HOSTAPD_LEVEL_DEBUG,
-- 
1.7.9.5

```
