### PR TITLE
Restore the deinit and free the mesh interfaces to avoid memory leak

### DIFF
--- a/wpa_supplicant/mesh.c
+++ b/wpa_supplicant/mesh.c
@@ -32,7 +32,9 @@ void wpa_supplicant_mesh_iface_deinit(struct hostapd_iface *ifmsh)
 		os_free(ifmsh->mconf);
 	}
 
-	mesh_mpm_deinit(ifmsh);
+	hostapd_interface_deinit(ifmsh);
+	hostapd_interface_free(ifmsh);
+
 	return;
 }
 

--- a/wpa_supplicant/mesh_mpm.c
+++ b/wpa_supplicant/mesh_mpm.c
@@ -178,13 +178,6 @@ wpa_mesh_set_plink_state(struct wpa_supplicant *wpa_s, struct sta_info *sta,
 	return;
 }
 
-void
-mesh_mpm_deinit(struct hostapd_iface *ifmsh)
-{
-	/* TODO: notify peers we're leaving */
-	/* TODO: deregister frames and events */
-}
-
 /* for mesh_rsn to indicate this peer has completed authentication, and we're
  * ready to start AMPE */
 void


### PR DESCRIPTION
```
From 8b721b8e983afa30b6f09d49d2e550f030782259 Mon Sep 17 00:00:00 2001
From: Chun-Yeow Yeoh <yeohchunyeow@cozybit.com>
Date: Tue, 13 Aug 2013 15:16:27 -0700
Subject: [PATCH] mesh: deinit or free the mesh interface to eliminate memory
 leak

Deinit and free the mesh interface accordingly to avoid memory leak
happened. Previous segmentation fault reported by Thomas is due to
the mesh_mpm_deinit is calling the hostapd_free_stas and this is also
called by hostapd_interface_deinit. mesh_mpm_deinit seems no longer
needed, so take this out as well.

Signed-off-by: Chun-Yeow Yeoh <yeohchunyeow@cozybit.com>

---
 wpa_supplicant/mesh.c     |    4 +++-
 wpa_supplicant/mesh_mpm.c |    7 -------
 2 files changed, 3 insertions(+), 8 deletions(-)

diff --git a/wpa_supplicant/mesh.c b/wpa_supplicant/mesh.c
index 8f7865e..eab9cfe 100644
--- a/wpa_supplicant/mesh.c
+++ b/wpa_supplicant/mesh.c
@@ -32,7 +32,9 @@ void wpa_supplicant_mesh_iface_deinit(struct hostapd_iface *ifmsh)
        os_free(ifmsh->mconf);
    }

-   mesh_mpm_deinit(ifmsh);
+   hostapd_interface_deinit(ifmsh);
+   hostapd_interface_free(ifmsh);
+
    return;
 }

diff --git a/wpa_supplicant/mesh_mpm.c b/wpa_supplicant/mesh_mpm.c
index 5df0a57..b4e0796 100644
--- a/wpa_supplicant/mesh_mpm.c
+++ b/wpa_supplicant/mesh_mpm.c
@@ -178,13 +178,6 @@ wpa_mesh_set_plink_state(struct wpa_supplicant *wpa_s, struct sta_info *sta,
    return;
 }

-void
-mesh_mpm_deinit(struct hostapd_iface *ifmsh)
-{
-   /* TODO: notify peers we're leaving */
-   /* TODO: deregister frames and events */
-}
-
 /* for mesh_rsn to indicate this peer has completed authentication, and we're
  * ready to start AMPE */
 void
-- 
1.7.9.5

```
