### PR TITLE
Set Authentication Protocol ID in Mesh Config Element

### DIFF
--- a/src/common/ieee802_11_defs.h
+++ b/src/common/ieee802_11_defs.h
@@ -1006,6 +1006,12 @@ enum wifi_display_subelem {
 #define MESH_PATH_METRIC_AIRTIME	1
 #define MESH_PATH_METRIC_VENDOR		255
 
+enum mesh_config_auth_proto {
+	AUTH_PROTO_NONE = 0x0,
+	AUTH_PROTO_SAE = 0x1,
+	AUTH_PROTO_8021X = 0x2,
+};
+
 #define OUI_BROADCOM 0x00904c /* Broadcom (Epigram) */
 
 #define VENDOR_HT_CAPAB_OUI_TYPE 0x33 /* 00-90-4c:0x33 */

--- a/src/drivers/driver_nl80211.c
+++ b/src/drivers/driver_nl80211.c
@@ -7174,8 +7174,10 @@ static int wpa_driver_nl80211_join_mesh(
 			params->ies);
 	}
 	/* WPA_DRIVER_MESH_FLAG_OPEN_AUTH is treated as default by nl80211 */
-	if (params->flags & WPA_DRIVER_MESH_FLAG_SAE_AUTH)
+	if (params->flags & WPA_DRIVER_MESH_FLAG_SAE_AUTH) {
 		NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_AUTH);
+		NLA_PUT_U8(msg, NL80211_MESH_SETUP_AUTH_PROTOCOL, AUTH_PROTO_SAE);
+	}
 	if (params->flags & WPA_DRIVER_MESH_FLAG_AMPE)
 		NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_AMPE);
 	if (params->flags & WPA_DRIVER_MESH_FLAG_USER_MPM)

--- a/src/drivers/nl80211_copy.h
+++ b/src/drivers/nl80211_copy.h
@@ -2420,6 +2420,9 @@ enum nl80211_meshconf_params {
  *
  * @NL80211_MESH_SETUP_ATTR_MAX: highest possible mesh setup attribute number
  *
+ * @NL80211_MESH_SETUP_AUTH_PROTOCOL: Inform the kernel of the authentication
+ *	method.
+ *
  * @__NL80211_MESH_SETUP_ATTR_AFTER_LAST: Internal use
  */
 enum nl80211_mesh_setup_params {
@@ -2431,6 +2434,7 @@ enum nl80211_mesh_setup_params {
 	NL80211_MESH_SETUP_USERSPACE_AMPE,
 	NL80211_MESH_SETUP_ENABLE_VENDOR_SYNC,
 	NL80211_MESH_SETUP_USERSPACE_MPM,
+	NL80211_MESH_SETUP_AUTH_PROTOCOL,
 
 	/* keep last */
 	__NL80211_MESH_SETUP_ATTR_AFTER_LAST,


### PR DESCRIPTION
```
From 18ecd8f4402da02aa392755fb4ad0dec0565d3d8 Mon Sep 17 00:00:00 2001
From: Chun-Yeow Yeoh <yeohchunyeow@cozybit.com>
Date: Thu, 15 Aug 2013 11:21:43 -0700
Subject: [PATCH] mesh: add mesh auth protocol ID accordingly

Kernel supports this, just add accordingly.

Signed-off-by: Chun-Yeow Yeoh <yeohchunyeow@cozybit.com>

---
 src/common/ieee802_11_defs.h |    6 ++++++
 src/drivers/driver_nl80211.c |    4 +++-
 src/drivers/nl80211_copy.h   |    4 ++++
 3 files changed, 13 insertions(+), 1 deletion(-)

diff --git a/src/common/ieee802_11_defs.h b/src/common/ieee802_11_defs.h
index 5b8437b..65dc670 100644
--- a/src/common/ieee802_11_defs.h
+++ b/src/common/ieee802_11_defs.h
@@ -1006,6 +1006,12 @@ enum wifi_display_subelem {
 #define MESH_PATH_METRIC_AIRTIME   1
 #define MESH_PATH_METRIC_VENDOR        255

+enum mesh_config_auth_proto {
+   AUTH_PROTO_NONE = 0x0,
+   AUTH_PROTO_SAE = 0x1,
+   AUTH_PROTO_8021X = 0x2,
+};
+
 #define OUI_BROADCOM 0x00904c /* Broadcom (Epigram) */

 #define VENDOR_HT_CAPAB_OUI_TYPE 0x33 /* 00-90-4c:0x33 */
diff --git a/src/drivers/driver_nl80211.c b/src/drivers/driver_nl80211.c
index 8f0d8d8..46eb9d0 100644
--- a/src/drivers/driver_nl80211.c
+++ b/src/drivers/driver_nl80211.c
@@ -7174,8 +7174,10 @@ static int wpa_driver_nl80211_join_mesh(
            params->ies);
    }
    /* WPA_DRIVER_MESH_FLAG_OPEN_AUTH is treated as default by nl80211 */
-   if (params->flags & WPA_DRIVER_MESH_FLAG_SAE_AUTH)
+   if (params->flags & WPA_DRIVER_MESH_FLAG_SAE_AUTH) {
        NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_AUTH);
+       NLA_PUT_U8(msg, NL80211_MESH_SETUP_AUTH_PROTOCOL, AUTH_PROTO_SAE);
+   }
    if (params->flags & WPA_DRIVER_MESH_FLAG_AMPE)
        NLA_PUT_FLAG(msg, NL80211_MESH_SETUP_USERSPACE_AMPE);
    if (params->flags & WPA_DRIVER_MESH_FLAG_USER_MPM)
diff --git a/src/drivers/nl80211_copy.h b/src/drivers/nl80211_copy.h
index 71dbecd..9125e16 100644
--- a/src/drivers/nl80211_copy.h
+++ b/src/drivers/nl80211_copy.h
@@ -2420,6 +2420,9 @@ enum nl80211_meshconf_params {
  *
  * @NL80211_MESH_SETUP_ATTR_MAX: highest possible mesh setup attribute number
  *
+ * @NL80211_MESH_SETUP_AUTH_PROTOCOL: Inform the kernel of the authentication
+ * method.
+ *
  * @__NL80211_MESH_SETUP_ATTR_AFTER_LAST: Internal use
  */
 enum nl80211_mesh_setup_params {
@@ -2431,6 +2434,7 @@ enum nl80211_mesh_setup_params {
    NL80211_MESH_SETUP_USERSPACE_AMPE,
    NL80211_MESH_SETUP_ENABLE_VENDOR_SYNC,
    NL80211_MESH_SETUP_USERSPACE_MPM,
+   NL80211_MESH_SETUP_AUTH_PROTOCOL,

    /* keep last */
    __NL80211_MESH_SETUP_ATTR_AFTER_LAST,
-- 
1.7.9.5

```
