### PR TITLE
mesh_mpm: don't check the WLAN_STA_AUTH flag for non secure mesh

### DIFF
--- a/wpa_supplicant/mesh_mpm.c
+++ b/wpa_supplicant/mesh_mpm.c
@@ -225,7 +225,8 @@ mesh_mpm_insert_sta(struct wpa_supplicant *wpa_s, struct sta_info *sta,
 	if (!sta)
 		return -ENOENT;
 
-	if (!(sta->flags & WLAN_STA_AUTH))
+	if (!(sta->flags & WLAN_STA_AUTH) &&
+	    (conf->security & MESH_CONF_SEC_AMPE))
 		return -EACCES;
 
 	/* initialize sta */


### PR DESCRIPTION
For non secure mesh, avoid checking the WLAN_STA_AUTH flag
before inserting the STA.

Signed-off-by: Chun-Yeow Yeoh yeohchunyeow@gmail.com
