### PR TITLE
mesh: Fix build error with CONFIG_MESH enabled

### DIFF
--- a/wpa_supplicant/Makefile
+++ b/wpa_supplicant/Makefile
@@ -204,6 +204,18 @@ NEED_SHA256=y
 NEED_AES_OMAC1=y
 endif
 
+ifdef CONFIG_MESH
+NEED_80211_COMMON=y
+NEED_SHA256=y
+NEED_AES_SIV=y
+NEED_AES_OMAC1=y
+NEED_AES_CTR=y
+CONFIG_SAE=y
+CONFIG_AP=y
+CFLAGS += -DCONFIG_MESH
+OBJS += mesh.o mesh_mpm.o mesh_rsn.o
+endif
+
 ifdef CONFIG_SAE
 CFLAGS += -DCONFIG_SAE
 OBJS += ../src/common/sae.o
@@ -250,15 +262,6 @@ ifdef CONFIG_IBSS_RSN
 NEED_RSN_AUTHENTICATOR=y
 CFLAGS += -DCONFIG_IBSS_RSN
 OBJS += ibss_rsn.o
-endif
-
-ifdef CONFIG_MESH
-NEED_80211_COMMON=y
-NEED_AES_SIV=y
-NEED_AES_OMAC1=y
-NEED_AES_CTR=y
-CFLAGS += -DCONFIG_MESH
-OBJS += mesh.o mesh_mpm.o mesh_rsn.o
 endif
 
 ifdef CONFIG_P2P


### PR DESCRIPTION
If CONFIG_MESH is enebled,
NEED_SHA256
CONFIG_SAE
CONFIG_AP
is needed for build.
