### PR TITLE
mesh: Fix build error with CONFIG_IEEE80211N disabled

### DIFF
--- a/wpa_supplicant/mesh.c
+++ b/wpa_supplicant/mesh.c
@@ -37,6 +37,7 @@ void wpa_supplicant_mesh_iface_deinit(struct wpa_supplicant *wpa_s,
 		return;
 
 	if (ifmsh->mconf) {
+		mesh_mpm_deinit(wpa_s, ifmsh);
 		if (ifmsh->mconf->ies)
 			ifmsh->mconf->ies = NULL;
 			/* We cannot free this struct
@@ -46,9 +47,9 @@ void wpa_supplicant_mesh_iface_deinit(struct wpa_supplicant *wpa_s,
 			 * let hostapd code free it.
 			 */
 		os_free(ifmsh->mconf);
+		ifmsh->mconf = NULL;
 	}
 
-	mesh_mpm_deinit(wpa_s, ifmsh);
 	/* take care of shared data */
 	/* FIX: ugly failures when NA to mesh */
 	hostapd_interface_deinit(ifmsh);

--- a/wpa_supplicant/mesh_mpm.c
+++ b/wpa_supplicant/mesh_mpm.c
@@ -344,9 +344,11 @@ wpa_mesh_new_mesh_peer(struct wpa_supplicant *wpa_s, const u8 *addr,
 
 	mesh_mpm_init_link(wpa_s, sta);
 
+#ifdef CONFIG_IEEE80211N
 	copy_sta_ht_capab(data, sta, elems->ht_capabilities,
 			elems->ht_capabilities_len);
 	update_ht_state(data, sta);
+#endif /* CONFIG_IEEE80211N */
 
 	/* insert into driver */
 	os_memset(&params, 0, sizeof(params));
@@ -395,7 +397,9 @@ static void mesh_mpm_send_plink_action(struct wpa_supplicant *wpa_s,
 	struct hostapd_data *bss = ifmsh->bss[0];
 	struct mesh_conf *conf = ifmsh->mconf;
 	u8 supp_rates[2 + 2 + 32];
+#ifdef CONFIG_IEEE80211N
 	u8 ht_capa_oper[2 + 26 + 2 + 22];
+#endif /* CONFIG_IEEE80211N */
 	u8 *pos, *cat;
 	u8 ie_len, add_plid = 0;
 	int ret;


### PR DESCRIPTION
Build fails when CONFIG_IEEE80211N is disabled.
